### PR TITLE
Added support for python 3.8 and dropped support for older Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: python
-python: '3.5'
+python:
+  - 3.5
+  - 3.8
 env:
-- TOXENV=django111
-- TOXENV=django20
-- TOXENV=django21
 - TOXENV=django22
-matrix:
-  include:
-  - python: '3.8'
-    env: TOXENV=py38-django22
-  - env: TOXENV=quality
+- TOXENV=quality
 install:
+- pip install pip==20.0.2
 - make requirements
 script:
 - tox
@@ -21,7 +17,7 @@ deploy:
     secure: qhgSqrSxjfHxTBvE9ioFnlVvmUPYdKrdpgvmJr/2ZukbCwqdS9w+S8tmtuRkvKuKGTZYp4im138oOAO6OFSLnC95nyWTb1vsC1SeUj544XxgbTsO5JILE9revU/p9vdkBepLzG0oz2Rj1N6h9qrCCc5GKpS7UMuz9Oxli+pbLRU=
   on:
     tags: true
-    python: '3.5'
-    condition: "$TOXENV = django111"
+    python: 3.5
+    condition: "$TOXENV = django22"
     distributions: sdist bdist_wheel
     repo: edx/django-lang-pref-middleware

--- a/lang_pref_middleware/__init__.py
+++ b/lang_pref_middleware/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this package template
 -c constraints.txt
 
-django>=1.11
+django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-django==2.2.11            # via -r requirements/base.in
-pytz==2019.3              # via django
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,3 +8,5 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+Django < 2.3
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,22 +7,20 @@
 appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
-coverage==5.0.4           # via -r requirements/test.txt
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
+coverage==5.1             # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
 django-nose==1.4.6        # via -r requirements/test.txt
-django==2.2.11            # via -r requirements/test.txt
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-importlib-metadata==1.5.0  # via -r requirements/travis.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 nose==1.3.7               # via -r requirements/test.txt, django-nose
 packaging==20.3           # via -r requirements/travis.txt, tox
 pep257==0.7.0             # via -r requirements/test.txt
-pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pip-tools==5.1.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/travis.txt, tox
 py==1.8.1                 # via -r requirements/travis.txt, tox
 pycodestyle==2.5.0        # via -r requirements/test.txt
@@ -30,14 +28,15 @@ pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.6          # via -r requirements/travis.txt, packaging
-pytz==2019.3              # via -r requirements/test.txt, django
+pyparsing==2.4.7          # via -r requirements/travis.txt, packaging
+pytz==2020.1              # via -r requirements/test.txt, django
 six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, packaging, pip-tools, tox, virtualenv
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 toml==0.10.0              # via -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/dev.in
-tox==3.14.5               # via -r requirements/travis.txt, tox-battery
-typed-ast==1.4.1          # via -r requirements/test.txt, astroid
-virtualenv==20.0.13       # via -r requirements/travis.txt, tox
+tox==3.15.0               # via -r requirements/travis.txt, tox-battery
+virtualenv==20.0.20       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/travis.txt, importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.1          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,8 +6,8 @@
 #
 astroid==2.3.3            # via pylint, pylint-celery
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
-coverage==5.0.4           # via -r requirements/test.in
+click==7.1.2              # via click-log, edx-lint
+coverage==5.1             # via -r requirements/test.in
 django-nose==1.4.6        # via -r requirements/test.in
 edx-lint==1.4.1           # via -r requirements/test.in
 isort==4.3.21             # via pylint
@@ -20,8 +20,7 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pytz==2019.3              # via -r requirements/base.txt, django
+pytz==2020.1              # via -r requirements/base.txt, django
 six==1.14.0               # via astroid, edx-lint
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-typed-ast==1.4.1          # via astroid
 wrapt==1.11.2             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,14 +7,11 @@
 appdirs==1.4.3            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/travis.in
-virtualenv==20.0.13       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+tox==3.15.0               # via -r requirements/travis.in
+virtualenv==20.0.20       # via tox

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py35-django{111,20,21,22},py38-django22,quality
+envlist = py35-django{22},py38-django{22,30},quality
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/test.txt
 commands = ./manage.py test --with-coverage --cover-inclusive --cover-branches --cover-html --cover-html-dir=build/coverage/html/ --cover-xml --cover-xml-file=build/coverage/coverage.xml --cover-package=lang_pref_middleware
 


### PR DESCRIPTION
this PR updates

- setup classifiers
- Travis configurations
- tox configurations
- Drops support for Django versions less than 2.2

Relevant JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1596).