### PR TITLE
unpinned importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,4 @@
 #
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2020.1              # via django
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,6 +9,3 @@
 # linking to it here is good.
 
 Django < 2.3
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -37,10 +37,10 @@ pytest-django==3.10.0     # via -r requirements/test.txt
 pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/test.txt, django
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, packaging, pathlib2, pip-tools, tox, virtualenv
-sqlparse==0.3.1           # via -r requirements/test.txt, django
+sqlparse==0.4.1           # via -r requirements/test.txt, django
 toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 virtualenv==20.0.33       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.3             # via -r requirements/test.in, pytest-cov
 edx-lint==1.5.2           # via -r requirements/test.in
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
@@ -31,7 +31,7 @@ pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.1.1             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, django
 six==1.15.0               # via astroid, edx-lint, packaging, pathlib2
-sqlparse==0.3.1           # via -r requirements/base.txt, django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
 toml==0.10.1              # via pytest
 typed-ast==1.4.1          # via astroid
 wrapt==1.11.2             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -15,6 +15,6 @@ py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.20.0               # via -r requirements/travis.in
+tox==3.20.1               # via -r requirements/travis.in
 virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.